### PR TITLE
tweak buttons to scroll to top and make popup wider

### DIFF
--- a/src/components/HomeCards/Card.tsx
+++ b/src/components/HomeCards/Card.tsx
@@ -17,7 +17,7 @@ const Card = ({ title, path, button, children }: CardProps) => {
       <Title fontSize='md'>{title}</Title>
       {/* <S.Pop>Learn hiragana and katakana</S.Pop> */}
       <S.CardText>{children}</S.CardText>
-      <Btn as={Link} to={path}>
+      <Btn as={Link} onClick={() => window.scrollTo(0, 0)} to={path}>
         {button}
       </Btn>
     </S.HomeCard>

--- a/src/components/NavBar/index.tsx
+++ b/src/components/NavBar/index.tsx
@@ -37,7 +37,7 @@ const NavBar: React.FC = () => {
     <S.NavContainer isopen={isOpen} scrollpos={scrollPos}>
       <S.NavbarWrapper>
         <S.LogoContainer>
-          <S.Logo to='/'>漢字を勉強する</S.Logo>
+          <S.Logo onClick={toggleOpen} to='/'>漢字を勉強する</S.Logo>
         </S.LogoContainer>
         <S.Menu isopen={isOpen} scrollpos={scrollPos}>
           {Object.entries(links).map(([name, path]) => {

--- a/src/components/Popup/styles.ts
+++ b/src/components/Popup/styles.ts
@@ -24,11 +24,11 @@ export const Popup = styled.div<PopupProps>`
   display: flex;
   flex-direction: column;
   gap: 3rem;
-  padding: 1rem 4rem;
+  padding: ${p => p.theme.compPadSm};
   box-sizing: border-box;
-  width: 50%;
+  /* width: 50%; */
   max-height: ${p => (p.vis && p.valueset ? '80vh' : '40vh')};
-  max-width: ${p => p.theme.mediaSm};
+  width: ${p => p.theme.mediaSm};
   font-size: 1.8rem;
   text-align: center;
   align-items: center;
@@ -42,7 +42,7 @@ export const Popup = styled.div<PopupProps>`
   transition: inherit;
 
   @media (max-width: ${p => p.theme.mediaSm}) {
-    width: 70%;
+    width: 90%;
   }
 
   &::-webkit-scrollbar {


### PR DESCRIPTION
- Scroll to top upon clicking Button in Homecards
- Make click on logo toggle the nav menu if on smaller viewport
- make popup wider on all viewports and reduce padding for better view in smaller screen sizes